### PR TITLE
Added better docs to the existing constants

### DIFF
--- a/buzzmobile/constants.yaml
+++ b/buzzmobile/constants.yaml
@@ -1,9 +1,26 @@
-image_width: 1200 # width of each world/gps/lidar model frame image
-image_height: 1200 # height of each world/gps/lidar model frame image
-pixels_per_m: 200 # number of pixels representing 1 meter in the frame images.
-travel_distance: 0.3 # distance between ackerman's steps in meters
-wheel_circumference: 2.198
+# Various constants for use throughout the project
+
+# These all relate to the shape of the interal representation of the world,
+# which is essentially a numpy array (or image) of `image_width` by 
+# `image_height` with a scale factor of `pixels_per_m`, corresponding to the
+# number of pixels per each real-world meter
+image_width: 1200
+image_height: 1200
+pixels_per_m: 200
+
+# Used for tentacle projection, travel distance is the step between each 
+# tentacle point, and num_points is the length of each tentacle, if using
+# liner, and not tentacle projection, ignore
+travel_distance: 0.3 
 num_points_in_tentacle: 50
+
+# Hardware values dealing with the car to define Ackerman parameters
+wheel_circumference: 2.198  # in meters, measured
 wheel_base: 1.8 # distance between front and back axels in meters
+
+# Hardware defined maximal steering angle to not break the vehicle
 max_steering_angle: 1.0 # radians
+
+# Resolution of potential paths, that is to say, the higher this number, the
+# more tentacles/linear paths will be judged
 angle_multiplier: 10 # this * max_angle is number of angles to span


### PR DESCRIPTION
In doing this I came across a potential error, namely our code that does the `np.linspace` in steering.py will break if we change `max_angle` to a non-integer float. See https://github.com/gtagency/buzzmobile/blob/master/buzzmobile/plan/steering/steering.py#L133 and the docs for linspace: https://docs.scipy.org/doc/numpy/reference/generated/numpy.linspace.html#numpy.linspace
