### PR TITLE
Revert "Add opencv3 as rosdep"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ before_install:
     # actually install ros
     - sudo apt-get install -qq -y python-catkin-pkg python-rosdep ros-$ROS_DISTRO-catkin ros-$ROS_DISTRO-ros
     - sudo apt-get install -qq -y ros-$ROS_DISTRO-roscpp ros-$ROS_DISTRO-rospy ros-$ROS_DISTRO-std-msgs ros-$ROS_DISTRO-cv-bridge ros-$ROS_DISTRO-usb-cam
-    # initialize dependency management
+    # install opencv and other special dependencies
+    - sudo apt-get install -qq ros-indigo-opencv3
     - sudo rosdep init
     - rosdep update
 
@@ -27,8 +28,6 @@ install:
    - cd ~/catkin_ws
 
 before_script: # Use this to prepare your build for testing e.g. copy database configurations, environment variables, etc.
-  - source /opt/ros/$ROS_DISTRO/setup.bash
+  - source /opt/ros/$ROS_DISTRO/setup.bash  
 script: # All commands must exit with code 0 on success. Anything else is considered failure.
   - catkin_make -j2
-  - source ~/catkin_ws/devel/setup.bash # Allow installing dependencies (recognizing buzzmobile)
-  - rosdep install buzzmobile # Install dependencies for buzzmobile

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ rosinit     # put these in your .bashrc too so they run everytime
 rosdevel    # you open a new terminal window/tab.
 ```
 
+We recommend using OpenCV 3. You can install it with:
+
+```bash
+sudo apt-get install ros-indigo-opencv3
+```
+
 To set up this repo, do:
 
 ```bash

--- a/buzzmobile/package.xml
+++ b/buzzmobile/package.xml
@@ -18,7 +18,6 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>message_generation</build_depend>
-  <build_depend>opencv3</build_depend>
 
   <run_depend>usb_cam</run_depend>
   <run_depend>nmea_navsat_driver</run_depend>
@@ -30,5 +29,4 @@
   <run_depend>cv_bridge</run_depend>
   <run_depend>message_generation</run_depend>
   <run_depend>message_runtime</run_depend>
-  <run_depend>opencv3</run_depend>
 </package>


### PR DESCRIPTION
Reverts gtagency/buzzmobile#52

Turns out that `opencv3` is a special dependency. According to http://wiki.ros.org/opencv3, you shouldn't put it as a dependency in your `package.xml` (it will fail, and this is why our travils builds have been red). Instead, you should depend on `cv_bridge` or `image_geometry`. Depending on one of those two keys transitively makes you depend on `libopencv-dev` on Jade and below, or `opencv3` on Kinetic and above.

We are using Indigo (below Jade), and want `opencv3`, not `libopencv-dev`, so we have to install `opencv3` in a special way.
