### PR TITLE
Add pytest tooling and examples

### DIFF
--- a/buzzmobile/sense/inputer/inputer.py
+++ b/buzzmobile/sense/inputer/inputer.py
@@ -10,7 +10,7 @@ def input_node():
     # Publish a nonsense initial value to make sure subscribers don't explode
     pub.publish("")
     while not rospy.is_shutdown():
-        new_dst = raw_input("Dest >> ")
+        new_dst = input("Dest >> ")
         pub.publish(new_dst)
 
 if __name__ == '__main__': input_node()

--- a/buzzmobile/tests/sense/test_inputer.py
+++ b/buzzmobile/tests/sense/test_inputer.py
@@ -15,9 +15,9 @@ class TestInputer(unittest.TestCase):
         rospy.init_node(NAME, anonymous=True)
 
         rospy.Subscriber('destination', String, callback)
-        timeout = time.time() + 1.0
+        timeout = time.time() + 2.0
 
-        while time.time() < timeout:
+        while time.time() < timeout and not rospy.is_shutdown():
             time.sleep(0.1)
 
     def __init__(self, *args):

--- a/buzzmobile/tests/sense/test_inputer.py
+++ b/buzzmobile/tests/sense/test_inputer.py
@@ -1,0 +1,55 @@
+import rostest
+import unittest
+import rospy
+import time
+from std_msgs.msg import String
+import roslaunch
+
+PKG = 'buzzmobile'
+NAME = 'test_inputer'
+
+
+class TestInputer(unittest.TestCase):
+
+    def run_node_with_callback(self, callback):
+        rospy.init_node(NAME, anonymous=True)
+
+        rospy.Subscriber('destination', String, callback)
+        timeout = time.time() + 1.0
+
+        while time.time() < timeout:
+            time.sleep(0.1)
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+
+    def setUp(self):
+        self.success = False
+        node = roslaunch.core.Node('buzzmobile', 'inputer.py')
+        launch = roslaunch.scriptapi.ROSLaunch()
+        launch.start()
+        self.process = launch.launch(node)
+
+    def test_inputer_no_input(self):
+        def cb(data):
+            self.success = (data.data == '')
+
+        self.run_node_with_callback(cb)
+        assert self.success
+
+    def test_sanity(self):
+        def cb(data):
+            self.success = (data.data == b'success')
+
+        self.run_node_with_callback(cb)
+        assert not self.success
+
+    def tearDown(self):
+        self.process.stop()
+
+
+if __name__ == '__main__':
+    rostest.rosrun(PKG, NAME, TestInputer)
+
+

--- a/ci_scripts/tests
+++ b/ci_scripts/tests
@@ -8,5 +8,14 @@ source bin/activate
 source /opt/ros/indigo/setup.sh
 source ../../devel/setup.sh
 
+# spin up roscore
+roscore&
+PID1=$!
+sleep 2
+
 # Run unit tests
 pytest buzzmobile/tests/
+
+# kill roscore when we are done
+kill $PID1
+sleep 2

--- a/ci_scripts/tests
+++ b/ci_scripts/tests
@@ -5,6 +5,8 @@ set -e
 
 # Activate VirtualEnv
 source bin/activate
+source /opt/ros/indigo/setup.sh
+source ../../devel/setup.sh
 
 # Run unit tests
-echo "Tests would go here"
+pytest buzzmobile/tests/


### PR DESCRIPTION
This contains some example tests. There is a question here: should we
run tests via catkin, or seperately? I think I can make them work in
catkin, but it will require some additional dependencies and cruft that
we may not need or want.

Alternatively, if we just run on pytest, we can configure coverage more
easily. I feel like that's a better way of doing things.

Also I should probably write a test.sh, since currently to run tests the
venv needs to be active and you need to have rosinited and sourced
`devel/setup.sh`.