### PR TITLE
Fixes steering score calculation

### DIFF
--- a/buzzmobile/launch/includes/steering.launch
+++ b/buzzmobile/launch/includes/steering.launch
@@ -1,4 +1,3 @@
 <launch>
-	<node pkg="buzzmobile" name="frame_merger" type="frame_merger.py"/>
 	<node pkg="buzzmobile" name="steering" type="steering.py"/>
 </launch>

--- a/buzzmobile/launch/steering_test.launch
+++ b/buzzmobile/launch/steering_test.launch
@@ -1,0 +1,8 @@
+<launch>
+  <group ns="buzzmobile">
+    <rosparam command="load" file="$(find buzzmobile)/constants.yaml"/>
+    <include file="$(find buzzmobile)/launch/steering_test/mock_sensors.launch"/>
+    <include file="$(find buzzmobile)/launch/steering_test/visualization.launch"/>
+    <include file="$(find buzzmobile)/launch/includes/steering.launch"/>
+  </group>
+</launch>

--- a/buzzmobile/launch/steering_test/mock_sensors.launch
+++ b/buzzmobile/launch/steering_test/mock_sensors.launch
@@ -1,0 +1,4 @@
+<launch>
+    <node pkg="rosbag" type="play" name="steering_murder" args="-l /bagfiles/steering.bag"/>
+</launch>
+

--- a/buzzmobile/launch/steering_test/visualization.launch
+++ b/buzzmobile/launch/steering_test/visualization.launch
@@ -1,0 +1,4 @@
+<launch>
+    <node pkg="rqt_gui" name="rqt_gui" type="rqt_gui" 
+          args="--perspective-file=$(find buzzmobile)/tools/mission_control/LidarTest.perspective"/>
+</launch>

--- a/buzzmobile/plan/steering/steering.py
+++ b/buzzmobile/plan/steering/steering.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-
+from __future__ import division
+# TODO(irapha): remove this line when #126 is fixed.
 
 import colorsys
 import cv2
@@ -169,6 +170,7 @@ def score_tentacle(points, frame):
     # must use np.sum because cv2 uses ints to store pixels. So sum(sum()) overflows.
     normalizing_factor = np.sum(np.sum(tentacle_mask))
     if normalizing_factor == 0.0:
+        rospy.logerr('Mask has no pixels')
         return 0.0
 
     tentacle_score_image = cv2.bitwise_and(frame, frame, mask=tentacle_mask)
@@ -182,7 +184,6 @@ def pick_tentacle(x_0, y_0, frame):
     and breaks ties by picking the tentacle with the smallest magnitude angle
     """
     angles = np.linspace(0.0, MAX_ANGLE, MAX_ANGLE * ANGLE_MULTIPLIER)
-    color_frame = cv2.cvtColor(frame, cv2.COLOR_GRAY2RGB)
 
     best_score = -1
     best_points = []
@@ -214,6 +215,10 @@ def score_to_color(score):
     return [255 * c for c in colorsys.hsv_to_rgb(
         score_to_h(score), score_to_s(score), score_to_v(score))]
 
+
+def draw_score(x, y, score, frame):
+    cv2.putText(frame, '{:.5}'.format(str(score)), (x, y),
+            cv2.FONT_HERSHEY_PLAIN, 1, score_to_color(1.0))
 
 def draw_points(points, color_frame, color, thickness=None):
     for i in range(len(points) - 1):


### PR DESCRIPTION
Was being rounded to 0 because of division problems in python2.

Fixes #134

Also adds the launch files I used for testing this bug. The databag is in the drive. If you download it to `~/name.bag` you can prepare it for this test with:

```bash
rosbag filter ~/name.bag /bagfiles/steering.bag 'topic == "/buzzmobile/world_model" or topic == "/buzzmobile/lidar_model"'
```