### PR TITLE
Fixed several issues causing Toyota mode

### DIFF
--- a/buzzmobile/drive/arduino/src/car_driver/car_driver.ino
+++ b/buzzmobile/drive/arduino/src/car_driver/car_driver.ino
@@ -101,7 +101,7 @@ void setup() {
 void loop() {
   digitalWrite(yellow_led, digitalRead(estop_pin));
   
-  char retMsg[30] = {0};
+  char retMsg[20] = {0};
   if(Serial.available()) {
     if(Serial.read() == '$') {
       speedController.setDesiredValue(Serial.parseFloat());
@@ -109,10 +109,12 @@ void loop() {
       digitalWrite(horn_pin, Serial.parseInt());
       
       lastCmdTime = millis();
-      retMsg[0] = '$';
-      sprintf(retMsg+1, "%05i,%05.4f,%05.4f", count, getSteeringAngle(), getSpeed());
-      // Odom callback temporarily disabled. See #41.
-      //Serial.println(retMsg);
+      char steeringStr[5] = {0};
+      char speedStr[5] = {0};
+      dtostrf(getSteeringAngle(), 5, 3, steeringStr);
+      dtostrf(getSpeed(), 5, 3, speedStr);
+      sprintf(retMsg, "$%05i,%s,%s", count, steeringStr, speedStr);
+      Serial.println(retMsg);
       count = 0;
     }
   }

--- a/buzzmobile/drive/car_interface/src/arduino.cpp
+++ b/buzzmobile/drive/car_interface/src/arduino.cpp
@@ -61,7 +61,7 @@ void Arduino::write_run() {
     } catch(...) {
       ROS_ERROR("An error occurred while writing to %s.", device_path.c_str());
     }
-    usleep(50000);
+    usleep(100000);
   }
 }
 

--- a/buzzmobile/drive/car_interface/src/main.cpp
+++ b/buzzmobile/drive/car_interface/src/main.cpp
@@ -20,6 +20,7 @@ Arduino arduino;
 ros::Time last_command_time;
 
 ros::Duration keep_alive_frequency(1.0);
+ros::Duration keep_alive_tolerance(0.5);
 
 void odometry_callback(int, float, float);
 
@@ -53,7 +54,8 @@ int main(int argc, char **argv) {
 void keep_alive_callback(const ros::TimerEvent&) {
   ROS_INFO("Keep alive callback called");
   // 1 sec command frequency required to maintain velocity
-  if((ros::Time::now() - last_command_time) > keep_alive_frequency) {
+  ros::Duration delta = ros::Time::now() - last_command_time;
+  if(delta > (keep_alive_frequency + keep_alive_tolerance)) {
     arduino.setSpeed(0);
   }
 }
@@ -68,7 +70,6 @@ void odometry_callback(int tickCount, float steeringAngle, float speed) {
 //void command_callback(core_msgs::MotionCommand::ConstPtr cmd) {
 void command_callback(buzzmobile::CarPose::ConstPtr cmd) {
   ROS_INFO("Command received, speed: %f, angle: %f", cmd->velocity, cmd->angle);
-  //arduino.setSpeed(cmd->speed);
   arduino.setSpeed(cmd->velocity);
   arduino.setSteering(cmd->angle);
   arduino.setHorn(cmd->horn);

--- a/buzzmobile/plan/car_pose_mux/car_pose_mux.py
+++ b/buzzmobile/plan/car_pose_mux/car_pose_mux.py
@@ -31,6 +31,7 @@ def publish():
     """Publishes current car_pose, if possible."""
     car_pose = mux(g['curr_car_state'])
     if car_pose is not None:
+	car_pose.header.stamp = rospy.Time.now()
         pub.publish(car_pose)
 
 def set_manual_car_pose(car_pose):


### PR DESCRIPTION
Fixes #144 and #145.

#144 was being caused by the fact that the Arduino cpp class was writing to the arduino faster than it could flush the data and process it. We believe #145 was a side effect of this.

This PR also fixes odometry callback ( #41 ) but is awaiting testing to close the issue. The initial guess we made in the comments seems to be wrong and reading from serial does not block writing.

Finally, this PR also makes sure that car_pose had a timestamp, which is necessary for car_interface to correctly calculate when it has timed out.