### PR TITLE
Add a CODEOWNERS file.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,7 @@
 * @irapha @joshuamorton
 
 # Language specific reviewers:
-*.py @iraphael @joshuamorton
+*.py @irapha @joshuamorton
 *.cpp @chsahit
 
 # Folder and package level ownership.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,21 @@
+# Code Ownership for buzzmobile.
+# Order matters. The last match is used, so more specific owners should be 
+# last.
+
+# Default owners/reviewers for anything.
+* @irapha @joshuamorton
+
+# Language specific reviewers:
+*.py @iraphael @joshuamorton
+*.cpp @chsahit
+
+# Folder and package level ownership.
+ci_scripts/* @irapha @joshuamorton
+
+# Buzzmobile subpackage overrides.
+buzzmobile/simulation/* @chsahit
+buzzmobile/tests/* @joshuamorton
+
+# File specific ownership.
+install @joshuamorton @coletaylor788
+buzzmobile/setup.py @joshuamorton

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 # last.
 
 # Default owners/reviewers for anything.
-* @irapha @joshuamorton
+* @irapha @joshuamorton @chsahit
 
 # Language specific reviewers:
 *.py @irapha @joshuamorton


### PR DESCRIPTION
This will automatically infer ownership information. I think there's
some bikeshedding to be had on who exactly should own what (ie. this
might be too "me"-centric), but it seems like a relatively safe starting
point.

Also, if we want, we can put this in a .github/ subdirectory. Which
isn't too important now, but you can put other thing like issue and pull
request templates there.