### PR TITLE
On our way to Simulation Tests

### DIFF
--- a/buzzmobile/launch/simulation_test.launch
+++ b/buzzmobile/launch/simulation_test.launch
@@ -1,0 +1,30 @@
+<launch>
+    <arg name="mission_control" default="false"/>
+    <arg name="gzclient" default="false" />
+    <arg name="world" default="$(find buzzmobile)/simulation/models/world/straight_road.world"/>
+
+    <group ns="buzzmobile">
+        <include file="$(find buzzmobile)/launch/includes/params.launch"/>
+        <include file="$(find buzzmobile)/launch/includes/gps.launch"/>
+        <!-- <include file="$(find buzzmobile)/launch/includes/mapping.launch"/> -->
+        <include file="$(find buzzmobile)/launch/includes/steering.launch"/>
+        <include file="$(find buzzmobile)/launch/includes/lidar.launch"/>
+        <include file="$(find buzzmobile)/launch/includes/controller.launch"/>
+        <group if="$(arg mission_control)">
+            <include file="$(find buzzmobile)/launch/includes/visualization.launch"/>
+        </group>
+        <include file="$(find buzzmobile)/launch/includes/sim_interface.launch"/>
+    </group>
+
+    <!-- Start gazebo server, load world, optionally start viz client -->
+    <node pkg="gazebo_ros" name="gazebo" type="gzserver"
+          args="-e ode $(arg world) use_sim_time:=true"
+          output="screen"/>
+    <group if="$(arg gzclient)">
+        <node pkg="gazebo_ros" name="gazebo_gui" type="gzclient"/>
+    </group>
+
+    <!-- Spawn Car -->
+    <!-- node pkg="buzzmobile" name="sim_spawn_car" type="sim_spawn_car.sh"/ -->
+    <include file="$(find buzzmobile)/launch/includes/sim_spawn_car.launch"/>
+</launch>

--- a/buzzmobile/sense/maps_querier/maps_querier.py
+++ b/buzzmobile/sense/maps_querier/maps_querier.py
@@ -11,7 +11,10 @@ Publishes:
 import googlemaps
 import rospy
 
-import googlemapskey as gmpskey
+try:
+    import googlemapskey as gmpskey
+except ImportError as e:
+    pass
 
 from datetime import datetime
 from sensor_msgs.msg import NavSatFix

--- a/buzzmobile/setup.py
+++ b/buzzmobile/setup.py
@@ -4,7 +4,7 @@
 # for downloading the packages needed for this project.
 from setuptools import setup
 
-test_requires = [
+TEST_REQUIRES = [
         'pytest==3.0.3',
         'netifaces==0.10.5',
         'pyrostest>=0.1.2',
@@ -28,5 +28,5 @@ setup(
         'rospkg==1.0.41',
         'ds4drv', # requires apt-get install python-dev
         'empy==3.3.2', # required to make catkin_make work
-        ] + test_requires,
+        ] + TEST_REQUIRES,
 )

--- a/buzzmobile/setup.py
+++ b/buzzmobile/setup.py
@@ -4,9 +4,15 @@
 # for downloading the packages needed for this project.
 from setuptools import setup
 
+test_requires = [
+        'pytest==3.0.3',
+        'netifaces==0.10.5',
+        'pyrostest>=0.1.2',
+        ]
+
 setup(
     name='buzzmobile',
-    version='0.3',
+    version='0.3.1',
     url='https://github.com/gtagency/buzzmobile',
     author='gtagency',
     license='MIT',
@@ -18,12 +24,9 @@ setup(
         'numpy==1.11.2',
         'polyline==1.3.1',
         'pylint',
-        'pytest==3.0.3',
         'pyyaml==3.12',
         'rospkg==1.0.41',
         'ds4drv', # requires apt-get install python-dev
         'empy==3.3.2', # required to make catkin_make work
-        'netifaces==0.10.5',  # required for testing
-        'pyrostest>=0.1.2',  # required for testing
-        ],
+        ] + test_requires,
 )

--- a/buzzmobile/tests/simulation/test_gazebo_connection.py
+++ b/buzzmobile/tests/simulation/test_gazebo_connection.py
@@ -10,8 +10,6 @@ class TestGazeboConnection(RosTest):
         """Test that simulation.launch correctly launches gazebo"""
         with self.check_topic('/clock', Clock) as ct:
             assert(ct.message)
-            print(ct.message)
-        time.sleep(30)
+        time.sleep(20)
         with self.check_topic('/clock', Clock, 20) as ct1:
-            print(ct1.message)
             assert(ct1.message)

--- a/buzzmobile/tests/simulation/test_gazebo_connection.py
+++ b/buzzmobile/tests/simulation/test_gazebo_connection.py
@@ -1,17 +1,20 @@
-from pyrostest import RosTest, with_launch_file
-from rosgraph_msgs.msg import Clock
+"""Simple simulation test to connect to Gazebo."""
+
 import time
+
+from rosgraph_msgs.msg import Clock
+
+from pyrostest import RosTest, with_launch_file
 
 class TestGazeboConnection(RosTest):
     """Tests for simulation testing infrastructure."""
 
-    @with_launch_file('buzzmobile', 'simulation.launch')
+    @with_launch_file('buzzmobile', 'simulation_test.launch')
     def test_clock_runs(self):
         """Test that simulation.launch correctly launches gazebo"""
         with self.check_topic('/clock', Clock) as ct:
             assert(ct.message)
-            print(ct.message)
-        time.sleep(30)
-        with self.check_topic('/clock', Clock, 20) as ct1:
-            print(ct1.message)
+
+        time.sleep(.1)
+        with self.check_topic('/clock', Clock, timeout=20) as ct1:
             assert(ct1.message)

--- a/ci_scripts/simulation
+++ b/ci_scripts/simulation
@@ -14,5 +14,5 @@ source ~/catkin_ws/devel/setup.bash
 cd ~/catkin_ws/src/buzzmobile/buzzmobile
 
 # Run unit tests
-pytest tests/simulation
+python -m pytest tests/simulation
 

--- a/ci_scripts/unittest
+++ b/ci_scripts/unittest
@@ -14,5 +14,5 @@ source ~/catkin_ws/devel/setup.bash
 cd ~/catkin_ws/src/buzzmobile/buzzmobile
 
 # Run unit tests
-pytest tests/unit
+python -m pytest tests/unit
 

--- a/ci_scripts/update_deps
+++ b/ci_scripts/update_deps
@@ -12,4 +12,4 @@ cd ~/catkin_ws/src
 rosdep install -y --from-paths ./buzzmobile/buzzmobile --ignore-src --rosdistro=indigo
 
 cd ~/catkin_ws/src/buzzmobile
-pip install -e buzzmobile
+python -m pip install -e buzzmobile


### PR DESCRIPTION
PTAL. `ci_scripts/simulation` passes locally, and so does `ci_scripts/unittest`, this feels stabler than it was before. 

I'm a bit confused by the horrendously long timeout required in the simulation test, but it's necessary.

Also running with `roslaunch buzzmobile simulation_test.launch gzclient:=True` works, which I don't think did for me before, but I have no clue why that is (also note I made some related changes in pyros). 

I'd like to be able to see rviz output as well, @sahit, do you know if there's a way to somehow show rviz data (or just do bits of buzzmobile namespaced topic visualization in gazebo)?